### PR TITLE
chore: update Sovereign dependencies to rev `3f94cecc`

### DIFF
--- a/.github/workflows/risc0-check.yml
+++ b/.github/workflows/risc0-check.yml
@@ -31,10 +31,12 @@ jobs:
           git config --global --replace-all "url.https://${{ secrets.AUTH_TOKEN }}@github.com.insteadOf" ssh://git@github.com
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
-      - name: Install cargo-risc0
-        run: cargo install cargo-risczero
+      - name: Install cargo-risczero
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-risczero@0.20
       - name: Install risc0-zkvm toolchain
-        run: cargo risczero install
+        run: cargo risczero install --version v2024-02-08.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check Risc0 compatibility

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
     "cSpell.words": [
         "jsonrpsee",
         "Rollup"
-    ]
+    ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
     "cSpell.words": [
         "jsonrpsee",
         "Rollup"
-    ],
+    ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "basecoin"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=71ee647#71ee6474f5f159a94333f6e7955d4078457e4993"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=9b214c7#9b214c70a872365e701b8d7a485a22efedc499ec"
 dependencies = [
  "basecoin-app",
  "basecoin-modules",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "basecoin-app"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=71ee647#71ee6474f5f159a94333f6e7955d4078457e4993"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=9b214c7#9b214c70a872365e701b8d7a485a22efedc499ec"
 dependencies = [
  "basecoin-modules",
  "basecoin-store",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "basecoin-modules"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=71ee647#71ee6474f5f159a94333f6e7955d4078457e4993"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=9b214c7#9b214c70a872365e701b8d7a485a22efedc499ec"
 dependencies = [
  "base64 0.21.7",
  "basecoin-store",
@@ -596,7 +596,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.8",
- "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
+ "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=81d5c5b)",
  "tendermint 0.34.0",
  "tendermint-rpc",
  "tonic",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "basecoin-store"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=71ee647#71ee6474f5f159a94333f6e7955d4078457e4993"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=9b214c7#9b214c70a872365e701b8d7a485a22efedc499ec"
 dependencies = [
  "displaydoc",
  "ics23",
@@ -5433,7 +5433,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b#adb8e7b6b7bc4a97c197b11b080989ff16240ae6"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=81d5c5b#81d5c5bed02d4df1e5a89af9092661be04c0da60"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -5441,7 +5441,7 @@ dependencies = [
  "ics23",
  "prost",
  "serde",
- "sov-celestia-client-types 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
+ "sov-celestia-client-types 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=81d5c5b)",
  "tendermint 0.34.0",
  "tendermint-light-client-verifier",
  "tendermint-proto 0.34.0",
@@ -5492,7 +5492,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b#adb8e7b6b7bc4a97c197b11b080989ff16240ae6"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=81d5c5b#81d5c5bed02d4df1e5a89af9092661be04c0da60"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -5579,7 +5579,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b#adb8e7b6b7bc4a97c197b11b080989ff16240ae6"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=81d5c5b#81d5c5bed02d4df1e5a89af9092661be04c0da60"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
@@ -5596,14 +5596,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
+ "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=81d5c5b)",
  "sov-chain-state",
- "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
+ "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=81d5c5b)",
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
  "thiserror",
  "time",
+ "tracing",
 ]
 
 [[package]]
@@ -5629,10 +5630,10 @@ dependencies = [
  "sha2 0.10.8",
  "sov-bank",
  "sov-celestia-adapter",
- "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
+ "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=81d5c5b)",
  "sov-chain-state",
- "sov-ibc 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
- "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
+ "sov-ibc 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=81d5c5b)",
+ "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=81d5c5b)",
  "sov-mock-da",
  "sov-mock-zkvm",
  "sov-modules-api",
@@ -5677,7 +5678,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b#adb8e7b6b7bc4a97c197b11b080989ff16240ae6"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=81d5c5b#81d5c5bed02d4df1e5a89af9092661be04c0da60"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "basecoin"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=bf4327d#bf4327deb8dccf9ca370ee7b5c1c3783013a2e17"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=71ee647#71ee6474f5f159a94333f6e7955d4078457e4993"
 dependencies = [
  "basecoin-app",
  "basecoin-modules",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "basecoin-app"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=bf4327d#bf4327deb8dccf9ca370ee7b5c1c3783013a2e17"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=71ee647#71ee6474f5f159a94333f6e7955d4078457e4993"
 dependencies = [
  "basecoin-modules",
  "basecoin-store",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "basecoin-modules"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=bf4327d#bf4327deb8dccf9ca370ee7b5c1c3783013a2e17"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=71ee647#71ee6474f5f159a94333f6e7955d4078457e4993"
 dependencies = [
  "base64 0.21.7",
  "basecoin-store",
@@ -596,7 +596,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.8",
- "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
+ "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
  "tendermint 0.34.0",
  "tendermint-rpc",
  "tonic",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "basecoin-store"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=bf4327d#bf4327deb8dccf9ca370ee7b5c1c3783013a2e17"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=71ee647#71ee6474f5f159a94333f6e7955d4078457e4993"
 dependencies = [
  "displaydoc",
  "ics23",
@@ -5433,7 +5433,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c#206b68cbe655d925a8c0a4198dcd9b72e406409a"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b#adb8e7b6b7bc4a97c197b11b080989ff16240ae6"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -5441,7 +5441,7 @@ dependencies = [
  "ics23",
  "prost",
  "serde",
- "sov-celestia-client-types 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
+ "sov-celestia-client-types 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
  "tendermint 0.34.0",
  "tendermint-light-client-verifier",
  "tendermint-proto 0.34.0",
@@ -5492,7 +5492,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c#206b68cbe655d925a8c0a4198dcd9b72e406409a"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b#adb8e7b6b7bc4a97c197b11b080989ff16240ae6"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -5578,7 +5578,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c#206b68cbe655d925a8c0a4198dcd9b72e406409a"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b#adb8e7b6b7bc4a97c197b11b080989ff16240ae6"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
@@ -5595,9 +5595,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
+ "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
  "sov-chain-state",
- "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
+ "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
@@ -5628,10 +5628,10 @@ dependencies = [
  "sha2 0.10.8",
  "sov-bank",
  "sov-celestia-adapter",
- "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
+ "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
  "sov-chain-state",
- "sov-ibc 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
- "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
+ "sov-ibc 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
+ "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b)",
  "sov-mock-da",
  "sov-mock-zkvm",
  "sov-modules-api",
@@ -5676,7 +5676,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c#206b68cbe655d925a8c0a4198dcd9b72e406409a"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=adb8e7b#adb8e7b6b7bc4a97c197b11b080989ff16240ae6"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,7 +1091,7 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 [[package]]
 name = "const-rollup-config"
 version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
 
 [[package]]
 name = "const_format"
@@ -4068,6 +4083,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
+ "protobuf",
  "thiserror",
 ]
 
@@ -4077,6 +4093,8 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags 2.4.2",
  "lazy_static",
  "num-traits",
@@ -4084,7 +4102,20 @@ dependencies = [
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax 0.8.2",
+ "rusty-fork",
+ "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4142,6 +4173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "protobuf-src"
 version = "1.1.0+21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4169,6 +4206,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -4355,9 +4398,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "0eea5a9eb898d3783f17c6407670e3592fd174cb81a10e51d4c37f49450b9946"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -4526,7 +4569,7 @@ dependencies = [
 [[package]]
 name = "risc0-cycle-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/risc0-cycle-macros.git?rev=98948b8ee0e3edffcee7f3bd95a9d93c5c0941af#98948b8ee0e3edffcee7f3bd95a9d93c5c0941af"
+source = "git+https://github.com/Sovereign-Labs/risc0-cycle-macros.git?rev=a00d0719388bcecd51b6033721957b27ffe12843#a00d0719388bcecd51b6033721957b27ffe12843"
 dependencies = [
  "bytes",
  "risc0-zkvm",
@@ -4663,6 +4706,22 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rockbound"
+version = "1.0.0"
+source = "git+https://github.com/sovereign-Labs/rockbound?tag=v2.0.0#edabd23e12d75058d7ce5d92e38dcc9f66f83c53"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "once_cell",
+ "prometheus",
+ "proptest",
+ "proptest-derive",
+ "rocksdb",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -4818,6 +4877,18 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ruzstd"
@@ -5010,6 +5081,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5268,6 +5348,24 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "clap",
+ "jsonrpsee",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "sov-bank"
+version = "0.3.0"
 source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
 dependencies = [
  "anyhow",
@@ -5277,15 +5375,15 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sov-modules-api",
- "sov-state",
+ "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
  "thiserror",
 ]
 
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5296,17 +5394,17 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sov-chain-state",
- "sov-modules-api",
+ "sov-chain-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "sov-sequencer-registry",
- "sov-state",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "tracing",
 ]
 
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5323,7 +5421,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-rollup-interface",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "tendermint 0.32.0",
  "tendermint-proto 0.32.0",
  "thiserror",
@@ -5433,6 +5531,22 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "derivative",
+ "jsonrpsee",
+ "serde",
+ "serde_json",
+ "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "tracing",
+]
+
+[[package]]
+name = "sov-chain-state"
+version = "0.3.0"
 source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
 dependencies = [
  "anyhow",
@@ -5440,9 +5554,28 @@ dependencies = [
  "jsonrpsee",
  "serde",
  "serde_json",
- "sov-modules-api",
- "sov-state",
+ "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
  "tracing",
+]
+
+[[package]]
+name = "sov-db"
+version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "borsh",
+ "byteorder",
+ "hex",
+ "jmt",
+ "rockbound",
+ "rocksdb",
+ "serde",
+ "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "tokio",
 ]
 
 [[package]]
@@ -5458,8 +5591,8 @@ dependencies = [
  "jmt",
  "rocksdb",
  "serde",
- "sov-modules-core",
- "sov-rollup-interface",
+ "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
  "sov-schema-db",
  "tokio",
 ]
@@ -5484,11 +5617,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "sov-celestia-client 0.1.0",
- "sov-chain-state",
+ "sov-chain-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "sov-ibc-transfer 0.1.0",
- "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
+ "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "thiserror",
  "time",
 ]
@@ -5514,11 +5647,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662)",
- "sov-chain-state",
+ "sov-chain-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
  "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662)",
- "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
+ "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
  "thiserror",
  "time",
 ]
@@ -5544,20 +5677,19 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-bank",
+ "sov-bank 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "sov-celestia-adapter",
  "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662)",
- "sov-chain-state",
+ "sov-chain-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "sov-ibc 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662)",
  "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662)",
  "sov-mock-da",
  "sov-mock-zkvm",
- "sov-modules-api",
+ "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "sov-modules-stf-blueprint",
  "sov-prover-storage-manager",
- "sov-rollup-interface",
- "sov-schema-db",
- "sov-state",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "tempfile",
  "tendermint 0.34.0",
  "tendermint-testgen",
@@ -5585,9 +5717,9 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sov-bank",
- "sov-modules-api",
- "sov-rollup-interface",
+ "sov-bank 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "thiserror",
  "uint",
 ]
@@ -5607,9 +5739,9 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sov-bank",
- "sov-modules-api",
- "sov-rollup-interface",
+ "sov-bank 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
  "thiserror",
  "uint",
 ]
@@ -5617,7 +5749,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5627,14 +5759,15 @@ dependencies = [
  "hex",
  "serde",
  "sha2 0.10.8",
- "sov-rollup-interface",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5642,12 +5775,34 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "rand",
- "schemars",
  "serde",
  "sha2 0.10.8",
- "sov-modules-api",
- "sov-rollup-interface",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+]
+
+[[package]]
+name = "sov-modules-api"
+version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
+dependencies = [
+ "anyhow",
+ "bech32",
+ "borsh",
+ "clap",
+ "derive_more",
+ "hex",
+ "jsonrpsee",
+ "rand",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-modules-macros 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -5667,12 +5822,33 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-modules-core",
- "sov-modules-macros",
- "sov-rollup-interface",
- "sov-state",
+ "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-modules-macros 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "sov-modules-core"
+version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
+dependencies = [
+ "anyhow",
+ "bech32",
+ "borsh",
+ "derivative",
+ "derive_more",
+ "digest 0.10.7",
+ "hex",
+ "jmt",
+ "proptest",
+ "schemars",
+ "serde",
+ "sha2 0.10.8",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "thiserror",
 ]
 
 [[package]]
@@ -5692,8 +5868,23 @@ dependencies = [
  "schemars",
  "serde",
  "sha2 0.10.8",
- "sov-rollup-interface",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
  "thiserror",
+]
+
+[[package]]
+name = "sov-modules-macros"
+version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "jsonrpsee",
+ "proc-macro2",
+ "quote",
+ "schemars",
+ "serde_json",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5714,7 +5905,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5722,11 +5913,11 @@ dependencies = [
  "jsonrpsee",
  "serde",
  "sov-blob-storage",
- "sov-chain-state",
- "sov-modules-api",
- "sov-modules-core",
- "sov-rollup-interface",
- "sov-state",
+ "sov-chain-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "thiserror",
  "tracing",
 ]
@@ -5734,14 +5925,35 @@ dependencies = [
 [[package]]
 name = "sov-prover-storage-manager"
 version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
 dependencies = [
  "anyhow",
- "sov-db",
- "sov-rollup-interface",
- "sov-schema-db",
- "sov-state",
+ "rockbound",
+ "sov-db 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
  "tracing",
+]
+
+[[package]]
+name = "sov-rollup-interface"
+version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "borsh",
+ "bytes",
+ "digest 0.10.7",
+ "futures",
+ "hex",
+ "proptest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -5770,7 +5982,6 @@ version = "0.3.0"
 source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
 dependencies = [
  "anyhow",
- "byteorder",
  "once_cell",
  "prometheus",
  "rocksdb",
@@ -5781,7 +5992,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5791,9 +6002,30 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sov-bank",
- "sov-modules-api",
- "sov-state",
+ "sov-bank 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+]
+
+[[package]]
+name = "sov-state"
+version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "borsh",
+ "derivative",
+ "hex",
+ "jmt",
+ "serde",
+ "serde-big-array",
+ "serde_json",
+ "sha2 0.10.8",
+ "sov-db 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "thiserror",
 ]
 
 [[package]]
@@ -5810,9 +6042,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-db",
- "sov-modules-core",
- "sov-rollup-interface",
+ "sov-db 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
  "thiserror",
 ]
 
@@ -5913,20 +6145,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6711,6 +6943,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5573,6 +5573,7 @@ dependencies = [
  "sov-state",
  "thiserror",
  "time",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "basecoin"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=63013eb#63013eb513a921f38af82707a1ea1f5dabc180c8"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=bf4327d#bf4327deb8dccf9ca370ee7b5c1c3783013a2e17"
 dependencies = [
  "basecoin-app",
  "basecoin-modules",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "basecoin-app"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=63013eb#63013eb513a921f38af82707a1ea1f5dabc180c8"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=bf4327d#bf4327deb8dccf9ca370ee7b5c1c3783013a2e17"
 dependencies = [
  "basecoin-modules",
  "basecoin-store",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "basecoin-modules"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=63013eb#63013eb513a921f38af82707a1ea1f5dabc180c8"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=bf4327d#bf4327deb8dccf9ca370ee7b5c1c3783013a2e17"
 dependencies = [
  "base64 0.21.7",
  "basecoin-store",
@@ -596,7 +596,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.8",
- "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662)",
+ "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
  "tendermint 0.34.0",
  "tendermint-rpc",
  "tonic",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "basecoin-store"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=63013eb#63013eb513a921f38af82707a1ea1f5dabc180c8"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=bf4327d#bf4327deb8dccf9ca370ee7b5c1c3783013a2e17"
 dependencies = [
  "displaydoc",
  "ics23",
@@ -5357,27 +5357,10 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-modules-api",
+ "sov-state",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "sov-bank"
-version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
-dependencies = [
- "anyhow",
- "borsh",
- "clap",
- "jsonrpsee",
- "schemars",
- "serde",
- "serde_json",
- "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "thiserror",
 ]
 
 [[package]]
@@ -5394,10 +5377,10 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sov-chain-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-chain-state",
+ "sov-modules-api",
  "sov-sequencer-registry",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-state",
  "tracing",
 ]
 
@@ -5421,7 +5404,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-rollup-interface",
  "tendermint 0.32.0",
  "tendermint-proto 0.32.0",
  "thiserror",
@@ -5450,7 +5433,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662#babc6620e6e3809074a4f4c022efdeb31153c5e9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c#206b68cbe655d925a8c0a4198dcd9b72e406409a"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -5458,7 +5441,7 @@ dependencies = [
  "ics23",
  "prost",
  "serde",
- "sov-celestia-client-types 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662)",
+ "sov-celestia-client-types 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
  "tendermint 0.34.0",
  "tendermint-light-client-verifier",
  "tendermint-proto 0.34.0",
@@ -5509,7 +5492,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662#babc6620e6e3809074a4f4c022efdeb31153c5e9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c#206b68cbe655d925a8c0a4198dcd9b72e406409a"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -5539,23 +5522,8 @@ dependencies = [
  "jsonrpsee",
  "serde",
  "serde_json",
- "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "tracing",
-]
-
-[[package]]
-name = "sov-chain-state"
-version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
-dependencies = [
- "anyhow",
- "borsh",
- "jsonrpsee",
- "serde",
- "serde_json",
- "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-modules-api",
+ "sov-state",
  "tracing",
 ]
 
@@ -5573,27 +5541,8 @@ dependencies = [
  "rockbound",
  "rocksdb",
  "serde",
- "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "tokio",
-]
-
-[[package]]
-name = "sov-db"
-version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
-dependencies = [
- "anyhow",
- "bincode",
- "borsh",
- "byteorder",
- "hex",
- "jmt",
- "rocksdb",
- "serde",
- "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-schema-db",
+ "sov-modules-core",
+ "sov-rollup-interface",
  "tokio",
 ]
 
@@ -5617,11 +5566,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "sov-celestia-client 0.1.0",
- "sov-chain-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-chain-state",
  "sov-ibc-transfer 0.1.0",
- "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-modules-api",
+ "sov-rollup-interface",
+ "sov-state",
  "thiserror",
  "time",
 ]
@@ -5629,7 +5578,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662#babc6620e6e3809074a4f4c022efdeb31153c5e9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c#206b68cbe655d925a8c0a4198dcd9b72e406409a"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
@@ -5646,12 +5595,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662)",
- "sov-chain-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662)",
- "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
+ "sov-chain-state",
+ "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
+ "sov-modules-api",
+ "sov-rollup-interface",
+ "sov-state",
  "thiserror",
  "time",
 ]
@@ -5677,19 +5626,19 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-bank 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-bank",
  "sov-celestia-adapter",
- "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662)",
- "sov-chain-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-ibc 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662)",
- "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662)",
+ "sov-celestia-client 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
+ "sov-chain-state",
+ "sov-ibc 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
+ "sov-ibc-transfer 0.1.0 (git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c)",
  "sov-mock-da",
  "sov-mock-zkvm",
- "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-prover-storage-manager",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-rollup-interface",
+ "sov-state",
  "tempfile",
  "tendermint 0.34.0",
  "tendermint-testgen",
@@ -5717,9 +5666,9 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sov-bank 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-bank",
+ "sov-modules-api",
+ "sov-rollup-interface",
  "thiserror",
  "uint",
 ]
@@ -5727,7 +5676,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=babc662#babc6620e6e3809074a4f4c022efdeb31153c5e9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=206b68c#206b68cbe655d925a8c0a4198dcd9b72e406409a"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -5739,9 +5688,9 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sov-bank 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-bank",
+ "sov-modules-api",
+ "sov-rollup-interface",
  "thiserror",
  "uint",
 ]
@@ -5759,7 +5708,7 @@ dependencies = [
  "hex",
  "serde",
  "sha2 0.10.8",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-rollup-interface",
  "tokio",
  "tracing",
 ]
@@ -5777,7 +5726,7 @@ dependencies = [
  "rand",
  "serde",
  "sha2 0.10.8",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-rollup-interface",
 ]
 
 [[package]]
@@ -5797,35 +5746,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-modules-macros 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "sov-modules-api"
-version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
-dependencies = [
- "anyhow",
- "bech32",
- "borsh",
- "clap",
- "derive_more",
- "hex",
- "jsonrpsee",
- "rand",
- "schemars",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-modules-macros 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-modules-core",
+ "sov-modules-macros",
+ "sov-rollup-interface",
+ "sov-state",
  "thiserror",
  "tracing",
 ]
@@ -5847,28 +5771,7 @@ dependencies = [
  "schemars",
  "serde",
  "sha2 0.10.8",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "thiserror",
-]
-
-[[package]]
-name = "sov-modules-core"
-version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
-dependencies = [
- "anyhow",
- "bech32",
- "borsh",
- "derivative",
- "derive_more",
- "digest 0.10.7",
- "hex",
- "jmt",
- "proptest",
- "schemars",
- "serde",
- "sha2 0.10.8",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-rollup-interface",
  "thiserror",
 ]
 
@@ -5876,21 +5779,6 @@ dependencies = [
 name = "sov-modules-macros"
 version = "0.3.0"
 source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc#3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b"
-dependencies = [
- "anyhow",
- "borsh",
- "jsonrpsee",
- "proc-macro2",
- "quote",
- "schemars",
- "serde_json",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "sov-modules-macros"
-version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5913,11 +5801,11 @@ dependencies = [
  "jsonrpsee",
  "serde",
  "sov-blob-storage",
- "sov-chain-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-chain-state",
+ "sov-modules-api",
+ "sov-modules-core",
+ "sov-rollup-interface",
+ "sov-state",
  "thiserror",
  "tracing",
 ]
@@ -5929,9 +5817,9 @@ source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f9
 dependencies = [
  "anyhow",
  "rockbound",
- "sov-db 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-db",
+ "sov-rollup-interface",
+ "sov-state",
  "tracing",
 ]
 
@@ -5954,39 +5842,6 @@ dependencies = [
  "sha2 0.10.8",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "sov-rollup-interface"
-version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
-dependencies = [
- "anyhow",
- "async-trait",
- "borsh",
- "bytes",
- "digest 0.10.7",
- "futures",
- "hex",
- "proptest",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "sov-schema-db"
-version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
-dependencies = [
- "anyhow",
- "once_cell",
- "prometheus",
- "rocksdb",
- "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -6002,9 +5857,9 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sov-bank 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-modules-api 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-state 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
+ "sov-bank",
+ "sov-modules-api",
+ "sov-state",
 ]
 
 [[package]]
@@ -6022,29 +5877,9 @@ dependencies = [
  "serde-big-array",
  "serde_json",
  "sha2 0.10.8",
- "sov-db 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=3f94cecc)",
- "thiserror",
-]
-
-[[package]]
-name = "sov-state"
-version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60#5a144d60eefaf9ce166bbfd66324b959aa4ae82b"
-dependencies = [
- "anyhow",
- "bcs",
- "borsh",
- "derivative",
- "hex",
- "jmt",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "sov-db 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-modules-core 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
- "sov-rollup-interface 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=5a144d60)",
+ "sov-db",
+ "sov-modules-core",
+ "sov-rollup-interface",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde_json  = "1.0"
 schemars    = { version = "0.8.12", features = ["derive"] }
 tempfile    = "3.5"
 thiserror   = "1.0.38"
+tracing = { version = "0.1.40", default-features = false }
 
 # ibc depedenencies
 ibc-core              = { git = "https://github.com/cosmos/ibc-rs.git", rev = "4463366e65", default-features = false, features = ["borsh","schema","serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,8 @@ tendermint-testgen    = { version = "0.34", default-features = false }
 tendermint-light-client-verifier = { version = "0.34", default-features = false }
 
 # sovereign dependencies
-sov-bank                   = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "5a144d60" }
-sov-chain-state            = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "5a144d60" }
-sov-modules-api            = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "5a144d60" }
-sov-state                  = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "5a144d60" }
-sov-rollup-interface       = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "5a144d60" }
+sov-bank                   = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "3f94cecc" }
+sov-chain-state            = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "3f94cecc" }
+sov-modules-api            = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "3f94cecc" }
+sov-state                  = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "3f94cecc" }
+sov-rollup-interface       = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "3f94cecc" }

--- a/mocks/Cargo.toml
+++ b/mocks/Cargo.toml
@@ -52,13 +52,12 @@ sov-modules-api            = { workspace = true }
 sov-rollup-interface       = { workspace = true }
 sov-state                  = { workspace = true }
 
-sov-celestia-adapter       = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "5a144d60", features = ["native"], optional = true }
-sov-mock-da                = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "5a144d60", features = ["native"], optional = true }
-sov-mock-zkvm              = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "5a144d60", features = ["native"], optional = true }
-sov-modules-stf-blueprint  = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "5a144d60", features = ["native"], optional = true }
-sov-prover-storage-manager = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "5a144d60", features = ["test-utils"] }
-sov-schema-db              = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "5a144d60" }
-const-rollup-config        = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "5a144d60" }
+sov-celestia-adapter       = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "3f94cecc", features = ["native"], optional = true }
+sov-mock-da                = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "3f94cecc", features = ["native"], optional = true }
+sov-mock-zkvm              = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "3f94cecc", features = ["native"], optional = true }
+sov-modules-stf-blueprint  = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "3f94cecc", features = ["native"], optional = true }
+sov-prover-storage-manager = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "3f94cecc", features = ["test-utils"] }
+const-rollup-config        = { git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git", rev = "3f94cecc" }
 jmt = { git = "https://github.com/penumbra-zone/jmt.git", rev = "1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6" }
 
 [dev-dependencies]

--- a/mocks/Cargo.toml
+++ b/mocks/Cargo.toml
@@ -28,9 +28,9 @@ tracing       = "0.1.36"
 typed-builder = "0.18.0"
 
 # internal dependencies
-sov-ibc               = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "babc662" }
-sov-ibc-transfer      = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "babc662" }
-sov-celestia-client   = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "babc662", features = ["test-util"] }
+sov-ibc               = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "206b68c" }
+sov-ibc-transfer      = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "206b68c" }
+sov-celestia-client   = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "206b68c", features = ["test-util"] }
 
 # ibc dependencies
 ibc-core              = { workspace = true }
@@ -41,7 +41,7 @@ ibc-query             = { workspace = true }
 ibc-testkit           = { git = "https://github.com/cosmos/ibc-rs.git", rev = "4463366e65", default-features = false }
 
 # cosmos dependencies
-basecoin         = { git = "https://github.com/informalsystems/basecoin-rs.git", rev = "63013eb" }
+basecoin         = { git = "https://github.com/informalsystems/basecoin-rs.git", rev = "bf4327d" }
 tendermint           = { workspace = true }
 tendermint-testgen   = { workspace = true }
 

--- a/mocks/Cargo.toml
+++ b/mocks/Cargo.toml
@@ -28,9 +28,9 @@ tracing       = "0.1.36"
 typed-builder = "0.18.0"
 
 # internal dependencies
-sov-ibc               = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "adb8e7b" }
-sov-ibc-transfer      = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "adb8e7b" }
-sov-celestia-client   = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "adb8e7b", features = ["test-util"] }
+sov-ibc               = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "81d5c5b" }
+sov-ibc-transfer      = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "81d5c5b" }
+sov-celestia-client   = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "81d5c5b", features = ["test-util"] }
 
 # ibc dependencies
 ibc-core              = { workspace = true }
@@ -41,7 +41,7 @@ ibc-query             = { workspace = true }
 ibc-testkit           = { git = "https://github.com/cosmos/ibc-rs.git", rev = "4463366e65", default-features = false }
 
 # cosmos dependencies
-basecoin         = { git = "https://github.com/informalsystems/basecoin-rs.git", rev = "71ee647" }
+basecoin             = { git = "https://github.com/informalsystems/basecoin-rs.git", rev = "9b214c7" }
 tendermint           = { workspace = true }
 tendermint-testgen   = { workspace = true }
 

--- a/mocks/Cargo.toml
+++ b/mocks/Cargo.toml
@@ -28,9 +28,9 @@ tracing       = "0.1.36"
 typed-builder = "0.18.0"
 
 # internal dependencies
-sov-ibc               = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "206b68c" }
-sov-ibc-transfer      = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "206b68c" }
-sov-celestia-client   = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "206b68c", features = ["test-util"] }
+sov-ibc               = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "adb8e7b" }
+sov-ibc-transfer      = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "adb8e7b" }
+sov-celestia-client   = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "adb8e7b", features = ["test-util"] }
 
 # ibc dependencies
 ibc-core              = { workspace = true }
@@ -41,7 +41,7 @@ ibc-query             = { workspace = true }
 ibc-testkit           = { git = "https://github.com/cosmos/ibc-rs.git", rev = "4463366e65", default-features = false }
 
 # cosmos dependencies
-basecoin         = { git = "https://github.com/informalsystems/basecoin-rs.git", rev = "bf4327d" }
+basecoin         = { git = "https://github.com/informalsystems/basecoin-rs.git", rev = "71ee647" }
 tendermint           = { workspace = true }
 tendermint-testgen   = { workspace = true }
 

--- a/mocks/src/sovereign/runner.rs
+++ b/mocks/src/sovereign/runner.rs
@@ -92,8 +92,10 @@ where
         let mut versioned_working_set =
             VersionedStateReadWriter::from_kernel_ws_virtual(kernel_working_set);
 
+        let visible_hash = <S as Spec>::VisibleHash::from(state_root);
+
         self.runtime()
-            .begin_slot_hook(&state_root, &mut versioned_working_set);
+            .begin_slot_hook(visible_hash, &mut versioned_working_set);
 
         let mut working_set = checkpoint.to_revertable(Default::default());
 
@@ -144,8 +146,10 @@ where
             .compute_state_update(cache_log, &witness)
             .expect("jellyfish merkle tree update must succeed");
 
+        let visible_root_hash = <S as Spec>::VisibleHash::from(root_hash);
+
         self.runtime()
-            .finalize_hook(&root_hash, &mut checkpoint.accessory_state());
+            .finalize_hook(visible_root_hash, &mut checkpoint.accessory_state());
 
         let accessory_log = checkpoint.freeze_non_provable();
 

--- a/mocks/src/sovereign/runtime/mod.rs
+++ b/mocks/src/sovereign/runtime/mod.rs
@@ -10,7 +10,6 @@ use sov_modules_api::{
     AccessoryStateCheckpoint, DaSpec, DispatchCall, Genesis, MessageCodec, Spec, StateCheckpoint,
     VersionedStateReadWriter,
 };
-use sov_state::Storage;
 
 #[derive(Genesis, DispatchCall, MessageCodec, DefaultRuntime, Clone)]
 #[serialization(serde::Serialize, serde::Deserialize)]
@@ -30,7 +29,7 @@ impl<S: Spec, Da: DaSpec> SlotHooks for Runtime<S, Da> {
 
     fn begin_slot_hook(
         &self,
-        _pre_state_root: &<<Self::Spec as Spec>::Storage as Storage>::Root,
+        _pre_state_root: <Self::Spec as Spec>::VisibleHash,
         _working_set: &mut VersionedStateReadWriter<StateCheckpoint<Self::Spec>>,
     ) {
     }
@@ -43,7 +42,7 @@ impl<S: Spec, Da: DaSpec> FinalizeHook for Runtime<S, Da> {
 
     fn finalize_hook(
         &self,
-        _root_hash: &<<Self::Spec as Spec>::Storage as Storage>::Root,
+        _root_hash: <Self::Spec as Spec>::VisibleHash,
         _accesorry_working_set: &mut AccessoryStateCheckpoint<Self::Spec>,
     ) {
     }

--- a/modules/sov-ibc/Cargo.toml
+++ b/modules/sov-ibc/Cargo.toml
@@ -22,6 +22,7 @@ sha2        = { version = "0.10.8", default-features = false }
 serde       = { workspace = true }
 serde_json  = { workspace = true, optional = true }
 thiserror   = { workspace = true }
+tracing     = { workspace = true }
 
 # internal dependencies
 sov-ibc-transfer = { path = "../sov-ibc-transfer" }

--- a/modules/sov-ibc/src/call.rs
+++ b/modules/sov-ibc/src/call.rs
@@ -46,7 +46,7 @@ impl<S: Spec, Da: DaSpec> Ibc<S, Da> {
         })?;
 
         info!(
-            "Processing IBC core message: {:?} at visible slot number {:?}",
+            "Processing IBC core message: {:?} at visible slot number: {:?}",
             msg_envelope,
             context.visible_slot_number()
         );
@@ -74,7 +74,7 @@ impl<S: Spec, Da: DaSpec> Ibc<S, Da> {
         working_set: &mut WorkingSet<S>,
     ) -> Result<CallResponse> {
         info!(
-            "Processing IBC transfer message: {:?} at visible slot number {:?}",
+            "Processing IBC transfer message: {:?} at visible_slot_number: {:?}",
             msg_transfer,
             context.visible_slot_number()
         );

--- a/modules/sov-ibc/src/rpc/methods.rs
+++ b/modules/sov-ibc/src/rpc/methods.rs
@@ -66,6 +66,8 @@ impl<S: Spec, Da: DaSpec> Ibc<S, Da> {
         request: QueryClientStateRequest,
         working_set: &mut WorkingSet<S>,
     ) -> RpcResult<QueryClientStateResponse> {
+        let namespace = self.client_state_map.namespace();
+
         let prefix = self.client_state_map.prefix();
 
         let codec = self.client_state_map.codec();
@@ -73,7 +75,7 @@ impl<S: Spec, Da: DaSpec> Ibc<S, Da> {
         let client_id =
             ClientId::from_str(request.client_id.as_str()).map_err(to_jsonrpsee_error)?;
 
-        let key = SlotKey::new(prefix, &client_id, codec.key_codec());
+        let key = SlotKey::new(namespace, prefix, &client_id, codec.key_codec());
 
         let value_with_proof = working_set.get_with_proof(key);
 
@@ -126,6 +128,8 @@ impl<S: Spec, Da: DaSpec> Ibc<S, Da> {
         request: QueryConsensusStateRequest,
         working_set: &mut WorkingSet<S>,
     ) -> RpcResult<QueryConsensusStateResponse> {
+        let namespace = self.consensus_state_map.namespace();
+
         let prefix = self.consensus_state_map.prefix();
 
         let codec = self.consensus_state_map.codec();
@@ -139,7 +143,7 @@ impl<S: Spec, Da: DaSpec> Ibc<S, Da> {
             request.revision_height,
         );
 
-        let key = SlotKey::new(prefix, &path, codec.key_codec());
+        let key = SlotKey::new(namespace, prefix, &path, codec.key_codec());
 
         let value_with_proof = working_set.get_with_proof(key);
 
@@ -389,6 +393,8 @@ impl<S: Spec, Da: DaSpec> Ibc<S, Da> {
         request: QueryPacketCommitmentRequest,
         working_set: &mut WorkingSet<S>,
     ) -> RpcResult<QueryPacketCommitmentResponse> {
+        let namespace = self.packet_commitment_map.namespace();
+
         let prefix = self.packet_commitment_map.prefix();
 
         let codec = self.packet_commitment_map.codec();
@@ -399,7 +405,7 @@ impl<S: Spec, Da: DaSpec> Ibc<S, Da> {
             request.sequence.into(),
         );
 
-        let key = SlotKey::new(prefix, &commitment_path, codec.key_codec());
+        let key = SlotKey::new(namespace, prefix, &commitment_path, codec.key_codec());
 
         let value_with_proof = working_set.get_with_proof(key);
 


### PR DESCRIPTION
## Description

- This PR updates Sovereign SDK dependencies to the rev `3f94cecc`, which corresponds to the [sov-rollup-starter-wip](https://github.com/Sovereign-Labs/sov-rollup-starter-wip) at `cc7b03c`.

- Additionally, included `tracing::info` at the `call` entrypoint of the `sov-ibc` module when it begins processing either of the IBC core or transfer messages.