### PR TITLE
fix: allow to set `genesis_da_height` on upgrades + some tech debts

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,7 +18,7 @@ ibc-primitives                  = { git = "https://github.com/cosmos/ibc-rs.git"
 ibc-query                       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "d5e3887770" }
 ibc-testkit                     = { git = "https://github.com/cosmos/ibc-rs.git", rev = "d5e3887770" }
 
-basecoin                        = { git = "https://github.com/informalsystems/basecoin-rs.git", rev = "b934e57" }
+basecoin                        = { git = "https://github.com/informalsystems/basecoin-rs.git", rev = "61256f9" }
 jmt                             = { git = "https://github.com/penumbra-zone/jmt.git", rev = "1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6" }
 
 sov-modules-api                 = { path = "vendor/sovereign-sdk/module-system/sov-modules-api" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "basecoin"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=b934e57#b934e57f5e109e69e4f1ba4391fd97f042a937ee"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=61256f9#61256f95e6491f040c9ba41ad04de4abb467cfb2"
 dependencies = [
  "basecoin-app",
  "basecoin-modules",
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "basecoin-app"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=b934e57#b934e57f5e109e69e4f1ba4391fd97f042a937ee"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=61256f9#61256f95e6491f040c9ba41ad04de4abb467cfb2"
 dependencies = [
  "basecoin-modules",
  "basecoin-store",
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "basecoin-modules"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=b934e57#b934e57f5e109e69e4f1ba4391fd97f042a937ee"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=61256f9#61256f95e6491f040c9ba41ad04de4abb467cfb2"
 dependencies = [
  "base64 0.21.7",
  "basecoin-store",
@@ -637,7 +637,7 @@ dependencies = [
 [[package]]
 name = "basecoin-store"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=b934e57#b934e57f5e109e69e4f1ba4391fd97f042a937ee"
+source = "git+https://github.com/informalsystems/basecoin-rs.git?rev=61256f9#61256f95e6491f040c9ba41ad04de4abb467cfb2"
 dependencies = [
  "displaydoc",
  "ics23",

--- a/clients/sov-celestia/types/src/client_message/header.rs
+++ b/clients/sov-celestia/types/src/client_message/header.rs
@@ -18,12 +18,12 @@ pub const SOV_TENDERMINT_HEADER_TYPE_URL: &str = "/ibc.lightclients.sovereign.te
 
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Header<H: Clone> {
+pub struct Header<H> {
     pub aggregated_proof: AggregatedProof,
     pub da_header: H,
 }
 
-impl<H: Clone> Debug for Header<H> {
+impl<H> Debug for Header<H> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         write!(f, "Header {{...}}")
     }

--- a/clients/sov-celestia/types/src/client_message/misbehaviour.rs
+++ b/clients/sov-celestia/types/src/client_message/misbehaviour.rs
@@ -20,13 +20,13 @@ pub const SOV_TENDERMINT_MISBEHAVIOUR_TYPE_URL: &str =
 /// Sovereign light client's misbehaviour type
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, PartialEq, Eq)]
-pub struct Misbehaviour<H: Clone> {
+pub struct Misbehaviour<H> {
     client_id: ClientId,
     header_1: Box<Header<H>>,
     header_2: Box<Header<H>>,
 }
 
-impl<H: Clone> Misbehaviour<H> {
+impl<H> Misbehaviour<H> {
     /// Creates a new misbehaviour
     pub fn new(client_id: ClientId, header_1: Header<H>, header_2: Header<H>) -> Self {
         Self {
@@ -52,7 +52,7 @@ impl<H: Clone> Misbehaviour<H> {
     }
 }
 
-impl<H: Clone> Debug for Misbehaviour<H> {
+impl<H> Debug for Misbehaviour<H> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/clients/sov-types/src/client_params.rs
+++ b/clients/sov-types/src/client_params.rs
@@ -93,9 +93,10 @@ impl SovereignClientParams {
     /// client upgrade process with the given upgraded client parameters.
     pub fn update_on_upgrade(self, upgraded: Self) -> Self {
         Self {
-            frozen_height: None,
+            genesis_da_height: upgraded.genesis_da_height,
             code_commitment: upgraded.code_commitment,
             latest_height: upgraded.latest_height,
+            frozen_height: None,
             upgrade_path: upgraded.upgrade_path,
             ..self
         }

--- a/modules/README.md
+++ b/modules/README.md
@@ -44,7 +44,7 @@ Here is an overview of the RPC methods available for each module:
 
 ### `sov-ibc` RPC Methods
 
-### Client
+#### Client
 
 - `ibc_clientState`
 - `ibc_clientStates`
@@ -55,7 +55,7 @@ Here is an overview of the RPC methods available for each module:
 - `ibc_upgradedClientState`
 - `ibc_upgradedConsensusState`
 
-### Connection
+#### Connection
 
 - `ibc_connection`
 - `ibc_connections`
@@ -64,7 +64,7 @@ Here is an overview of the RPC methods available for each module:
 - `ibc_connectionConsensusState`
 - `ibc_connectionParams`
 
-### Channel
+#### Channel
 
 - `ibc_channel`
 - `ibc_channels`
@@ -80,10 +80,15 @@ Here is an overview of the RPC methods available for each module:
 - `ibc_unreceivedAcks`
 - `ibc_nextSequenceReceive`
 
+#### Example
+
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"ibc_clientState","params":{"request":{"client_id": "100-sov-celestia-0"}},"id":1}' http://127.0.0.1:12345
+```
+
 ### `sov-ibc-transfer` RPC Methods
 
-- `transfer_escrowedToken`: Searches the list of escrowed tokens based on the
-  provided token denomination and returns the corresponding token ID, if
-  available.
-- `transfer_mintedToken` : Searches the list of minted tokens based on the provided
-  token denomination and returns the corresponding token ID, if available.
+- `transfer_mintedTokenName`: Queries the minted tokens by provided token ID
+  and returns the corresponding token name.
+- `transfer_mintedTokenId`: Queries the minted tokens by provided token name and
+  returns the corresponding token ID.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                    ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Allowed to set `genesis_da_height` on client upgrade, because in Cosmos chains the `revision_height` resets during upgrades.
- Fixed `basecoin` patch
- A few technical debts
