### PR TITLE
Use git URL for normal cargo build, and vendored file path for Nix build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -21,17 +21,72 @@ ibc-testkit                     = { git = "https://github.com/cosmos/ibc-rs.git"
 basecoin                        = { git = "https://github.com/informalsystems/basecoin-rs.git", rev = "61256f9" }
 jmt                             = { git = "https://github.com/penumbra-zone/jmt.git", rev = "1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6" }
 
-sov-modules-api                 = { path = "vendor/sovereign-sdk/module-system/sov-modules-api" }
-sov-state                       = { path = "vendor/sovereign-sdk/module-system/sov-state" }
-sov-bank                        = { path = "vendor/sovereign-sdk/module-system/module-implementations/sov-bank" }
-sov-sequencer-registry          = { path = "vendor/sovereign-sdk/module-system/module-implementations/sov-sequencer-registry" }
-sov-db                          = { path = "vendor/sovereign-sdk/full-node/sov-db" }
-sov-rollup-interface            = { path = "vendor/sovereign-sdk/rollup-interface" }
-sov-mock-zkvm                   = { path = "vendor/sovereign-sdk/adapters/mock-zkvm" }
-sov-prover-storage-manager      = { path = "vendor/sovereign-sdk/full-node/sov-prover-storage-manager" }
-sov-kernels                     = { path = "vendor/sovereign-sdk/module-system/sov-kernels" }
-sov-modules-core                = { path = "vendor/sovereign-sdk/module-system/sov-modules-core" }
-sov-celestia-adapter            = { path = "vendor/sovereign-sdk/adapters/celestia" }
-sov-mock-da                     = { path = "vendor/sovereign-sdk/adapters/mock-da" }
-const-rollup-config             = { path = "vendor/sovereign-sdk/examples/const-rollup-config" }
-sov-chain-state                 = { path = "vendor/sovereign-sdk/module-system/module-implementations/sov-chain-state" }
+[patch.crates-io.sov-modules-api]
+# path = "vendor/sovereign-sdk/module-system/sov-modules-api"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.sov-state]
+# path = "vendor/sovereign-sdk/module-system/sov-state"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.sov-bank]
+# path = "vendor/sovereign-sdk/module-system/module-implementations/sov-bank"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.sov-sequencer-registry]
+# path = "vendor/sovereign-sdk/module-system/module-implementations/sov-sequencer-registry"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.sov-db]
+# path = "vendor/sovereign-sdk/full-node/sov-db"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.sov-rollup-interface]
+# path = "vendor/sovereign-sdk/rollup-interface"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.sov-mock-zkvm]
+# path = "vendor/sovereign-sdk/adapters/mock-zkvm"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.sov-prover-storage-manager]
+# path = "vendor/sovereign-sdk/full-node/sov-prover-storage-manager"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.sov-kernels]
+# path = "vendor/sovereign-sdk/module-system/sov-kernels"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.sov-modules-core]
+# path = "vendor/sovereign-sdk/module-system/sov-modules-core"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.sov-celestia-adapter]
+# path = "vendor/sovereign-sdk/adapters/celestia"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.sov-mock-da]
+# path = "vendor/sovereign-sdk/adapters/mock-da"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.const-rollup-config]
+# path = "vendor/sovereign-sdk/examples/const-rollup-config"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"
+
+[patch.crates-io.sov-chain-state]
+# path = "vendor/sovereign-sdk/module-system/module-implementations/sov-chain-state"
+git = "ssh://git@github.com/informalsystems/sovereign-sdk-wip.git"
+rev = "63fa5f11"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,3 @@
-
 [patch.crates-io]
 
 sov-ibc                         = { path = "modules/sov-ibc" }
@@ -20,6 +19,13 @@ ibc-testkit                     = { git = "https://github.com/cosmos/ibc-rs.git"
 
 basecoin                        = { git = "https://github.com/informalsystems/basecoin-rs.git", rev = "61256f9" }
 jmt                             = { git = "https://github.com/penumbra-zone/jmt.git", rev = "1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6" }
+
+
+# The sovereign-sdk patches are specified in two modes.
+# In the normal mode, the uncommented git URLs would allow Cargo to fetch from sovereign-sdk private git repository.
+# In Nix mode, the git lines are commented, and the path lines are uncommented, to fetch sovereign-sdk
+# modules from a local vendor file path.
+# As a result, _both_ git and path entries for each sovereign-sdk module is required, with the path section commented.
 
 [patch.crates-io.sov-modules-api]
 # path = "vendor/sovereign-sdk/module-system/sov-modules-api"

--- a/.github/workflows/cw-check.yml
+++ b/.github/workflows/cw-check.yml
@@ -22,9 +22,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.AUTH_TOKEN }}
+      - name: Set up Git credentials for private repo
+        run: |
+          git config --global --replace-all \
+          "url.https://${{ secrets.AUTH_TOKEN }}@github.com.insteadOf" \
+          ssh://git@github.com
       - uses: cachix/install-nix-action@v26
         with:
           extra_nix_config: |

--- a/.github/workflows/risc0-check.yml
+++ b/.github/workflows/risc0-check.yml
@@ -26,9 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.AUTH_TOKEN }}
+      - name: Set up Git credentials for private repo
+        run: |
+          git config --global --replace-all \
+          "url.https://${{ secrets.AUTH_TOKEN }}@github.com.insteadOf" \
+          ssh://git@github.com
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
       - name: Install cargo-risczero

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,9 +55,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.AUTH_TOKEN }}
+      - name: Set up Git credentials for private repo
+        run: |
+          git config --global --replace-all \
+          "url.https://${{ secrets.AUTH_TOKEN }}@github.com.insteadOf" \
+          ssh://git@github.com
       - uses: arduino/setup-protoc@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -75,9 +77,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.AUTH_TOKEN }}
+      - name: Set up Git credentials for private repo
+        run: |
+          git config --global --replace-all \
+          "url.https://${{ secrets.AUTH_TOKEN }}@github.com.insteadOf" \
+          ssh://git@github.com
       - uses: arduino/setup-protoc@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -93,9 +97,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.AUTH_TOKEN }}
+      - name: Set up Git credentials for private repo
+        run: |
+          git config --global --replace-all \
+          "url.https://${{ secrets.AUTH_TOKEN }}@github.com.insteadOf" \
+          ssh://git@github.com
       - uses: arduino/setup-protoc@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -112,9 +118,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.AUTH_TOKEN }}
+      - name: Set up Git credentials for private repo
+        run: |
+          git config --global --replace-all \
+          "url.https://${{ secrets.AUTH_TOKEN }}@github.com.insteadOf" \
+          ssh://git@github.com
       - uses: arduino/setup-protoc@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -132,9 +140,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.AUTH_TOKEN }}
+      - name: Set up Git credentials for private repo
+        run: |
+          git config --global --replace-all \
+          "url.https://${{ secrets.AUTH_TOKEN }}@github.com.insteadOf" \
+          ssh://git@github.com
       - uses: arduino/setup-protoc@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/sovereign-sdk"]
-	path = vendor/sovereign-sdk
-	url = git@github.com:informalsystems/sovereign-sdk-wip.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,7 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 [[package]]
 name = "const-rollup-config"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 
 [[package]]
 name = "const_format"
@@ -5421,6 +5422,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
@@ -5439,6 +5441,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5459,6 +5462,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5540,6 +5544,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5596,6 +5601,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5732,6 +5738,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -5744,6 +5751,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5761,6 +5769,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5778,6 +5787,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
@@ -5802,6 +5812,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-core"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5824,6 +5835,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
@@ -5840,6 +5852,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-storage-manager"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "rockbound",
@@ -5852,6 +5865,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5873,6 +5887,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5891,6 +5906,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=63fa5f11#63fa5f110ebb323100ff740e6b152ba42a6ae84c"
 dependencies = [
  "anyhow",
  "bcs",

--- a/nix/sov-celestia-cw.nix
+++ b/nix/sov-celestia-cw.nix
@@ -56,7 +56,7 @@ let
             cp -r ${sovereign-sdk-src} $out/vendor/sovereign-sdk
 
             cp ${cargo-lock-file} $out/Cargo.lock
-            cat ${cargo-toml-file} > $out/Cargo.toml
+            cp ${cargo-toml-file} $out/Cargo.toml
         '';
     };
 

--- a/nix/sov-celestia-cw.nix
+++ b/nix/sov-celestia-cw.nix
@@ -4,6 +4,42 @@
 ,   sovereign-sdk-src
 }:
 let
+    # Use local file path instead of git URL for sovereign-sdk dependencies
+    patch-section = builtins.replaceStrings
+        [
+            "# path = \"vendor/sovereign-sdk"
+            "git = \"ssh://git@github.com/informalsystems/sovereign-sdk-wip.git\"\nrev = "
+        ]
+        [
+            "path = \"vendor/sovereign-sdk"
+            "# git = \"ssh://git@github.com/informalsystems/sovereign-sdk-wip.git\"\n# rev = "
+        ]
+        (builtins.readFile ../.cargo/config.toml)
+    ;
+
+    # Comment out Cargo.lock lines that include sovereign-sdk source, since we switch to local file path
+    cargo-lock = builtins.replaceStrings
+        [ "source = \"git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git" ]
+        [ "# source = \"git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git" ]
+        (builtins.readFile ../Cargo.lock)
+    ;
+
+    cargo-toml-file = builtins.toFile
+        "Cargo.toml"
+        ( builtins.concatStringsSep
+            "\n"
+            [
+                (builtins.readFile ../Cargo.toml)
+                patch-section
+            ]
+        )
+    ;
+
+    cargo-lock-file = builtins.toFile
+        "Cargo.lock"
+        cargo-lock
+    ;
+
     sov-celestia-src = nixpkgs.stdenv.mkDerivation {
         name = "sov-celestia-src";
         dontUnpack = true;
@@ -16,11 +52,11 @@ let
             cp -r ${../modules} $out/modules
             cp -r ${../mocks} $out/mocks
             cp -r ${../proto} $out/proto
-            cp -r ${sovereign-sdk-src} $out/vendor/sovereign-sdk
-            cp ${../Cargo.lock} $out/Cargo.lock
 
-            cat ${../Cargo.toml} > $out/Cargo.toml
-            cat ${../.cargo/config.toml} >> $out/Cargo.toml
+            cp -r ${sovereign-sdk-src} $out/vendor/sovereign-sdk
+
+            cp ${cargo-lock-file} $out/Cargo.lock
+            cat ${cargo-toml-file} > $out/Cargo.toml
         '';
     };
 
@@ -29,7 +65,7 @@ let
         src = sov-celestia-src;
 
         cargoLock = {
-            lockFile = ../Cargo.lock;
+            lockFile = cargo-lock-file;
             outputHashes = {
                 "basecoin-0.1.0" = "sha256-7huJeHyrS8GVQqE3nu/VEHxuPWsFqEDo1kabLbenBYA=";
                 "celestia-proto-0.1.0" = "sha256-iUgrctxdJUyhfrEQ0zoVj5AKIqgj/jQVNli5/K2nxK0=";


### PR DESCRIPTION
## Summary

- Removes the use of git submodule.
- Use normal Git URL to fetch the private sovereign-sdk repository when building with `cargo build`.
- Use vendored file path when building in Nix.
- Use separate toml entries for each Sovereign SDK dependency
  - Each entry would have uncommented git URL, and commented path value
  - The Nix build would uncomment the path value, and comment out the git URLs.

## Motivation

The use of git submodule turns out to not work well with Cargo. When one tries to run `cargo build` with git dependencies with git submodules, Cargo will almost always try to also fetch the git submodule, whether it is required in the Cargo dependency or not.

Because of this, we need to use back git dependency for Sovereign SDK modules. On the other hand, in Nix we would patch the git dependencies, and replace them with path dependencies in order to work in Nix. This is because the Nix Rust build still does not support private repository, and we still need to use local vendored file path dependency inside the Nix build.